### PR TITLE
Auto-increment CI build number for App Store uploads

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -154,6 +154,10 @@ jobs:
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          # Monotonically increasing build number so App Store Connect always
+          # sees a higher CFBundleVersion than the previous upload. Overrides
+          # the project's CURRENT_PROJECT_VERSION only for this archive.
+          BUILD_NUMBER: ${{ github.run_number }}
         run: |
           xcodebuild -scheme "$SCHEME" \
             -archivePath $RUNNER_TEMP/cyfaceapp.xcarchive \
@@ -163,6 +167,7 @@ jobs:
             -authenticationKeyID $APP_STORE_CONNECT_KEY_ID \
             -authenticationKeyIssuerID $APP_STORE_CONNECT_ISSUER_ID \
             -allowProvisioningUpdates \
+            CURRENT_PROJECT_VERSION=$BUILD_NUMBER \
             clean archive
 
       - name: Export IPA


### PR DESCRIPTION
Uploads were rejected with a 409 because CFBundleVersion stayed at 1 and App Store Connect requires each build to have a higher version than the previous upload. Override CURRENT_PROJECT_VERSION with the monotonically increasing GitHub run number at archive time.