### PR TITLE
Build on iOS 26 SDK and bump marketing version to 6.0.1

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,7 +24,7 @@ jobs:
   # ---------------------------------------------------------------------------
   test:
     name: Test
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     name: Build & Upload to App Store Connect
     needs: test
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       SCHEME: ${{ github.event.inputs.scheme || 'Cyface Production' }}
       TEAM_ID: '45GZ5C9N64'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,8 +31,12 @@ jobs:
 
       - name: Run Unit Tests
         run: |
+          # Simulator names change across runner images, so select the first
+          # available iPhone simulator instead of pinning a specific model.
+          UDID=$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ {print $2; exit}')
+          echo "Using simulator $UDID"
           xcodebuild -scheme "Cyface Development" \
-            -destination "platform=iOS Simulator,name=iPhone SE (3rd generation)" \
+            -destination "id=$UDID" \
             -skip-testing:cyfaceappUITests \
             test
 

--- a/cyfaceapp.xcodeproj/project.pbxproj
+++ b/cyfaceapp.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.0;
+				MARKETING_VERSION = 6.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -522,7 +522,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.0;
+				MARKETING_VERSION = 6.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -662,7 +662,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.0;
+				MARKETING_VERSION = 6.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -795,7 +795,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.0;
+				MARKETING_VERSION = 6.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -928,7 +928,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.0;
+				MARKETING_VERSION = 6.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1061,7 +1061,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.0.0;
+				MARKETING_VERSION = 6.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
App Store Connect now rejects builds made with the iOS 18.5 SDK; move the CI jobs to the macos-26 runner, whose default Xcode 26.5 provides the iOS 26 SDK.

Also bump MARKETING_VERSION to 6.0.1 for the app target, since 6.0.0 is already released and its version train is closed for new uploads.